### PR TITLE
Add skeleton project layout and schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,11 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Repository data
+.agents/
+
+# Repository data
+results/*
+!results/results-schema.json
+.agents/

--- a/anomaly_models/__init__.py
+++ b/anomaly_models/__init__.py
@@ -1,0 +1,8 @@
+"""Anomaly detection models."""
+from .base import BaseAnomalyModel
+from .isolation_forest import IsolationForestModel
+
+__all__ = [
+    "BaseAnomalyModel",
+    "IsolationForestModel",
+]

--- a/anomaly_models/base.py
+++ b/anomaly_models/base.py
@@ -1,0 +1,36 @@
+"""Base classes for anomaly detection models."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional
+import numpy as np
+
+ArrayLike = np.ndarray
+NDArray = np.ndarray
+
+
+class BaseAnomalyModel(ABC):
+    """Abstract base class for anomaly detection models."""
+
+    @abstractmethod
+    def fit(self, X: ArrayLike, y: Optional[ArrayLike] | None = None) -> "BaseAnomalyModel":
+        """Fit the model."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def score_samples(self, X: ArrayLike) -> NDArray:
+        """Compute anomaly scores for ``X``."""
+        raise NotImplementedError
+
+    def predict(self, X: ArrayLike, *, threshold: float | None = None) -> NDArray:
+        """Predict binary labels using ``threshold`` or ``self.decision_threshold``."""
+        if threshold is None:
+            threshold = self.decision_threshold
+        scores = self.score_samples(X)
+        return (scores >= threshold).astype(int)
+
+    @property
+    @abstractmethod
+    def decision_threshold(self) -> float:
+        """Threshold used for ``predict``."""
+        raise NotImplementedError

--- a/anomaly_models/isolation_forest.py
+++ b/anomaly_models/isolation_forest.py
@@ -1,0 +1,32 @@
+"""Isolation Forest model wrapper."""
+from __future__ import annotations
+
+from typing import Optional
+from sklearn.ensemble import IsolationForest  # type: ignore[import-untyped]
+
+from .base import BaseAnomalyModel, ArrayLike, NDArray
+
+
+class IsolationForestModel(BaseAnomalyModel):
+    """Wrapper around :class:`~sklearn.ensemble.IsolationForest`."""
+
+    def __init__(self, **params: Optional[int]):
+        self.model = IsolationForest(**params)
+        self._threshold: float | None = None
+
+    def fit(self, X: ArrayLike, y: Optional[ArrayLike] | None = None) -> "IsolationForestModel":
+        self.model.fit(X)
+        return self
+
+    def score_samples(self, X: ArrayLike) -> NDArray:
+        scores: NDArray = -self.model.decision_function(X)
+        return scores
+
+    @property
+    def decision_threshold(self) -> float:
+        if self._threshold is None:
+            raise RuntimeError("Model has no threshold set")
+        return self._threshold
+
+    def set_threshold(self, value: float) -> None:
+        self._threshold = value

--- a/datasets/registry.py
+++ b/datasets/registry.py
@@ -1,0 +1,16 @@
+"""Dataset registry and loaders."""
+from __future__ import annotations
+
+from typing import Tuple, Optional
+import numpy as np
+
+NDArray = np.ndarray
+Dataset = Tuple[NDArray, Optional[NDArray]]
+
+
+def load_dataset(name: str, split: str = "train") -> Dataset:
+    """Load a dataset by name.
+
+    This is a placeholder implementation.
+    """
+    raise NotImplementedError

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,1 @@
+# Documentation

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -1,0 +1,1 @@
+# Experiments

--- a/results/results-schema.json
+++ b/results/results-schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Benchmark Result",
+  "type": "object",
+  "properties": {
+    "dataset": {"type": "string"},
+    "model": {"type": "string"},
+    "n_samples": {"type": "integer"},
+    "seed": {"type": "integer"},
+    "hardware": {"type": "string"},
+    "roc_auc": {"type": "number"},
+    "pr_auc": {"type": "number"},
+    "f1": {"type": "number"},
+    "threshold": {"type": "number"},
+    "fit_time": {"type": "number"},
+    "score_time": {"type": "number"},
+    "params": {"type": "object"}
+  },
+  "required": [
+    "dataset", "model", "n_samples", "seed", "hardware",
+    "roc_auc", "pr_auc", "f1", "threshold", "fit_time",
+    "score_time", "params"
+  ]
+}

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,4 @@
+"""Placeholder test suite."""
+
+def test_placeholder() -> None:
+    assert True


### PR DESCRIPTION
## Summary
- scaffold directories for anomaly models, datasets, experiments, docs and tests
- implement placeholder base model and isolation forest wrapper
- add dataset registry stub
- include initial pytest stub and documentation placeholder
- add `results/results-schema.json` for benchmark outputs
- ignore generated results and agent helpers in git

## Testing
- `ruff check .`
- `mypy --strict --exclude 'nothing' .`
- `pytest -q`
- `sphinx-build -b html docs docs/_build` *(fails: config directory doesn't contain a conf.py file)*

------
https://chatgpt.com/codex/tasks/task_e_687c5d78e51c8324ad1c6deb1ccd313e