### PR TITLE
Add quick start sample to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # anml-exp
 A unified interface to prototype and test anomaly detection methods.
+
+## Quick Start
+
+```python
+from anomaly_models.isolation_forest import IsolationForestModel
+from datasets.registry import load_dataset
+from sklearn.metrics import roc_auc_score
+
+# Load synthetic toy data
+X_train, _ = load_dataset("toy-blobs", split="train")
+X_test, y_test = load_dataset("toy-blobs", split="test")
+
+# Fit and score
+model = IsolationForestModel(n_estimators=200).fit(X_train)
+scores = model.score_samples(X_test)
+
+print("ROC-AUC:", roc_auc_score(y_test, scores))
+```
+
+The snippet above mirrors the quick‑start example from the project spec and
+should execute after installing the package (the optional `[torch]` extras are
+not required).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,22 @@
 # Documentation
+
+## Quick Start
+
+```python
+from anomaly_models.isolation_forest import IsolationForestModel
+from datasets.registry import load_dataset
+from sklearn.metrics import roc_auc_score
+
+# Load synthetic toy data
+X_train, _ = load_dataset("toy-blobs", split="train")
+X_test, y_test = load_dataset("toy-blobs", split="test")
+
+# Fit and score
+model = IsolationForestModel(n_estimators=200).fit(X_train)
+scores = model.score_samples(X_test)
+
+print("ROC-AUC:", roc_auc_score(y_test, scores))
+```
+
+The above snippet is taken from the project specification and serves as a
+minimal working example.


### PR DESCRIPTION
## Summary
- embed the quick-start code snippet in the README and docs

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`
- `sphinx-build -b html docs docs/_build/html` *(fails: config directory doesn't contain a conf.py)*
- `jsonschema results/results-schema.json -i results/results-schema.json` *(fails: required property errors)*

------
https://chatgpt.com/codex/tasks/task_e_687c6a8b592c83249c24046ec6a8baad