### PR TITLE
Add toy dataset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,12 @@ A unified interface to prototype and test anomaly detection methods.
 
 ## Benchmarking
 
-Run `evaluator.py` to execute a benchmark and produce a JSON result conforming
-to `results/results-schema.json`.
+Run ``evaluator.py`` to execute a benchmark and produce a JSON result
+conforming to ``results/results-schema.json``.
+
+```bash
+python evaluator.py \
+    --dataset toy-blobs \
+    --model isolation_forest \
+    --output results/example.json
+```

--- a/datasets/registry.py
+++ b/datasets/registry.py
@@ -4,14 +4,81 @@ from __future__ import annotations
 from typing import Optional, Tuple
 
 import numpy as np
+from sklearn.datasets import make_blobs  # type: ignore[import-untyped]
 
 NDArray = np.ndarray
 Dataset = Tuple[NDArray, Optional[NDArray]]
 
 
-def load_dataset(name: str, split: str = "train") -> Dataset:
+def _toy_blobs(split: str, *, seed: int) -> Dataset:
+    """Synthetic Gaussian blobs for quick experiments.
+
+    The training split contains a single Gaussian cluster representing
+    "normal" data. The test split mixes the same cluster with an equal
+    number of points from a second, well separated cluster which are
+    labelled as anomalies.
+
+    Data are generated via :func:`sklearn.datasets.make_blobs` and are
+    fully deterministic given ``seed``.
+
+    References
+    ----------
+    * F. Pedregosa et al., "Scikit-learn: Machine Learning in Python",
+      Journal of Machine Learning Research, 2011.
+    """
+
+    rng = np.random.default_rng(seed)
+
+    if split == "train":
+        X, _ = make_blobs(
+            n_samples=100,
+            centers=[[0.0, 0.0]],
+            cluster_std=0.5,
+            random_state=rng.integers(0, 2**32 - 1),
+        )
+        return X.astype(np.float64), None
+
+    if split == "test":
+        X_norm, _ = make_blobs(
+            n_samples=50,
+            centers=[[0.0, 0.0]],
+            cluster_std=0.5,
+            random_state=rng.integers(0, 2**32 - 1),
+        )
+        X_anom, _ = make_blobs(
+            n_samples=50,
+            centers=[[4.0, 4.0]],
+            cluster_std=0.5,
+            random_state=rng.integers(0, 2**32 - 1),
+        )
+        X = np.vstack([X_norm, X_anom]).astype(np.float64)
+        y = np.hstack([
+            np.zeros(len(X_norm), dtype=int),
+            np.ones(len(X_anom), dtype=int),
+        ])
+        return X, y
+
+    raise KeyError(f"Unknown split: {split}")
+
+
+_REGISTRY = {"toy-blobs": _toy_blobs}
+
+
+def load_dataset(name: str, split: str = "train", *, seed: int = 42) -> Dataset:
     """Load a dataset by name.
 
-    This is a placeholder implementation.
+    Parameters
+    ----------
+    name:
+        Dataset identifier.
+    split:
+        ``"train"`` or ``"test"``.
+    seed:
+        Random seed controlling synthetic data generation.
     """
-    raise NotImplementedError
+
+    try:
+        loader = _REGISTRY[name]
+    except KeyError as exc:
+        raise KeyError(f"Unknown dataset: {name!r}") from exc
+    return loader(split, seed=seed)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,22 @@
 # Documentation
+
+## Loading datasets
+
+Use :func:`datasets.registry.load_dataset` to obtain deterministic splits. The
+example below fetches the synthetic ``toy-blobs`` data::
+
+    from datasets.registry import load_dataset
+
+    X_train, _ = load_dataset("toy-blobs", split="train")
+    X_test, y_test = load_dataset("toy-blobs", split="test")
+
+## Running the evaluator
+
+The benchmark runner can be invoked from the command line::
+
+    python evaluator.py \
+        --dataset toy-blobs \
+        --model isolation_forest \
+        --output results/example.json
+
+This writes a JSON file compatible with ``results/results-schema.json``.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import numpy.testing as npt
+
+from datasets.registry import load_dataset
+
+
+def test_toy_blobs_deterministic() -> None:
+    X_train1, y_train1 = load_dataset("toy-blobs", split="train", seed=0)
+    X_train2, y_train2 = load_dataset("toy-blobs", split="train", seed=0)
+    X_test1, y_test1 = load_dataset("toy-blobs", split="test", seed=0)
+    X_test2, y_test2 = load_dataset("toy-blobs", split="test", seed=0)
+
+    assert y_train1 is None
+    assert y_train2 is None
+
+    npt.assert_array_equal(X_train1, X_train2)
+    npt.assert_array_equal(X_test1, X_test2)
+    npt.assert_array_equal(y_test1, y_test2)
+
+
+def test_toy_blobs_shapes() -> None:
+    X_train, y_train = load_dataset("toy-blobs", split="train")
+    X_test, y_test = load_dataset("toy-blobs", split="test")
+
+    assert y_train is None
+    assert X_train.shape == (100, 2)
+    assert X_test.shape == (100, 2)
+    assert y_test is not None
+    assert y_test.shape == (100,)


### PR DESCRIPTION
## Summary
- implement deterministic dataset loader
- document toy dataset and usage
- add dataset unit tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c735e3b4883249e214c508c60c5b8