### PR TITLE
Add toy circles dataset

### DIFF
--- a/datasets/registry.py
+++ b/datasets/registry.py
@@ -61,7 +61,56 @@ def _toy_blobs(split: str, *, seed: int) -> Dataset:
     raise KeyError(f"Unknown split: {split}")
 
 
-_REGISTRY = {"toy-blobs": _toy_blobs}
+
+def _toy_circles(split: str, *, seed: int) -> Dataset:
+    """Synthetic concentric circles classification toy dataset.
+
+    The training split consists solely of the inner circle, representing
+    normal observations. The test split contains an equal number of points
+    from both the inner circle and the outer ring. Points on the outer ring
+    are labelled as anomalies.
+
+    Data are generated via :func:`sklearn.datasets.make_circles` and are fully
+    deterministic given ``seed``.
+
+    References
+    ----------
+    * F. Pedregosa et al., "Scikit-learn: Machine Learning in Python",
+      Journal of Machine Learning Research, 2011.
+    """
+
+    from sklearn.datasets import make_circles
+
+    rng = np.random.default_rng(seed)
+
+    if split == "train":
+        X, y = make_circles(
+            n_samples=200,
+            noise=0.05,
+            factor=0.3,
+            random_state=rng.integers(0, 2**32 - 1),
+        )
+        X_inner = X[y == 1]
+        return X_inner.astype(np.float64), None
+
+    if split == "test":
+        X, y = make_circles(
+            n_samples=200,
+            noise=0.05,
+            factor=0.3,
+            random_state=rng.integers(0, 2**32 - 1),
+        )
+        # points on the outer ring are anomalies
+        y = (y == 0).astype(int)
+        return X.astype(np.float64), y
+
+    raise KeyError(f"Unknown split: {split}")
+
+
+_REGISTRY = {
+    "toy-blobs": _toy_blobs,
+    "toy-circles": _toy_circles,
+}
 
 
 def load_dataset(name: str, split: str = "train", *, seed: int = 42) -> Dataset:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -28,3 +28,28 @@ def test_toy_blobs_shapes() -> None:
     assert X_test.shape == (100, 2)
     assert y_test is not None
     assert y_test.shape == (100,)
+
+
+def test_toy_circles_deterministic() -> None:
+    X_train1, y_train1 = load_dataset("toy-circles", split="train", seed=0)
+    X_train2, y_train2 = load_dataset("toy-circles", split="train", seed=0)
+    X_test1, y_test1 = load_dataset("toy-circles", split="test", seed=0)
+    X_test2, y_test2 = load_dataset("toy-circles", split="test", seed=0)
+
+    assert y_train1 is None
+    assert y_train2 is None
+
+    npt.assert_array_equal(X_train1, X_train2)
+    npt.assert_array_equal(X_test1, X_test2)
+    npt.assert_array_equal(y_test1, y_test2)
+
+
+def test_toy_circles_shapes() -> None:
+    X_train, y_train = load_dataset("toy-circles", split="train")
+    X_test, y_test = load_dataset("toy-circles", split="test")
+
+    assert y_train is None
+    assert X_train.shape == (100, 2)
+    assert X_test.shape == (200, 2)
+    assert y_test is not None
+    assert y_test.shape == (200,)


### PR DESCRIPTION
## Summary
- add toy-circles dataset loader with deterministic splits
- test deterministic behaviour and shapes

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c76adc6208324a5866c50576203ad