### PR TITLE
Add breast cancer dataset loader

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,12 @@ The benchmark runner can be invoked from the command line::
 - ``one_class_svm``
 
 This writes a JSON file compatible with ``results/results-schema.json``.
+
+## Available datasets
+
+The following dataset identifiers can be passed to
+``datasets.registry.load_dataset``:
+
+- ``toy-blobs``
+- ``toy-circles``
+- ``breast-cancer``

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -53,3 +53,29 @@ def test_toy_circles_shapes() -> None:
     assert X_test.shape == (200, 2)
     assert y_test is not None
     assert y_test.shape == (200,)
+
+
+def test_breast_cancer_deterministic() -> None:
+    X_train1, y_train1 = load_dataset("breast-cancer", split="train", seed=0)
+    X_train2, y_train2 = load_dataset("breast-cancer", split="train", seed=0)
+    X_test1, y_test1 = load_dataset("breast-cancer", split="test", seed=0)
+    X_test2, y_test2 = load_dataset("breast-cancer", split="test", seed=0)
+
+    assert y_train1 is None
+    assert y_train2 is None
+
+    npt.assert_array_equal(X_train1, X_train2)
+    npt.assert_array_equal(X_test1, X_test2)
+    npt.assert_array_equal(y_test1, y_test2)
+
+
+def test_breast_cancer_shapes() -> None:
+    X_train, y_train = load_dataset("breast-cancer", split="train")
+    X_test, y_test = load_dataset("breast-cancer", split="test")
+
+    assert y_train is None
+    # number of benign samples in training may vary due to split, check shape
+    assert X_train.shape[1] == X_test.shape[1] == 30
+    assert y_test is not None
+    assert y_test.ndim == 1
+


### PR DESCRIPTION
## Summary
- add a deterministic `breast-cancer` dataset loader
- register the dataset and document in README
- expand dataset unit tests

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c812a576083248d5ea49da61389e8