### PR TITLE
Add experiment configs and runner

### DIFF
--- a/experiments/toy-blobs.yaml
+++ b/experiments/toy-blobs.yaml
@@ -1,0 +1,11 @@
+# Experiment: toy-blobs dataset with all reference models
+dataset: toy-blobs
+seed: 42
+hardware: CPU-unknown
+output_dir: results/toy-blobs
+models:
+  isolation_forest:
+    n_estimators: 100
+  local_outlier_factor: {}
+  one_class_svm:
+    gamma: 0.1

--- a/experiments/toy-circles.yaml
+++ b/experiments/toy-circles.yaml
@@ -1,0 +1,11 @@
+# Experiment: toy-circles dataset with all reference models
+dataset: toy-circles
+seed: 42
+hardware: CPU-unknown
+output_dir: results/toy-circles
+models:
+  isolation_forest:
+    n_estimators: 100
+  local_outlier_factor: {}
+  one_class_svm:
+    gamma: 0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "numpy",
     "scipy",
     "scikit-learn",
+    "jsonschema",
 ]
 
 [project.optional-dependencies]

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -1,0 +1,57 @@
+"""Execute benchmark experiments defined in YAML configs."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml  # type: ignore[import-untyped]
+
+from evaluator import run_benchmark
+
+SCHEMA_PATH = Path("results/results-schema.json")
+
+
+def _validate(result: dict[str, Any]) -> None:
+    """Validate ``result`` using ``results/results-schema.json``."""
+    import jsonschema  # type: ignore[import-untyped]
+
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(result, schema)
+
+
+def _run(config: Path) -> None:
+    data = yaml.safe_load(config.read_text())
+
+    dataset = data["dataset"]
+    seed = int(data.get("seed", 42))
+    hardware = str(data.get("hardware", "unknown"))
+    output_dir = Path(data.get("output_dir", f"results/{config.stem}"))
+
+    models: dict[str, Any] = data["models"]
+
+    for model_name, params in models.items():
+        params = params or {}
+        out_file = output_dir / f"{model_name}.json"
+        result = run_benchmark(
+            dataset=dataset,
+            model_name=model_name,
+            seed=seed,
+            hardware=hardware,
+            output=out_file,
+            **params,
+        )
+        _validate(result)
+        print(json.dumps(result, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run experiment YAML")
+    parser.add_argument("config", type=Path, help="Path to YAML config")
+    args = parser.parse_args()
+    _run(args.config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple experiment YAMLs for toy datasets
- add a helper script to run YAML experiments and validate outputs
- depend on `jsonschema` for schema validation

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c8190c0e88324ae9bb6eb8d6f22ec