### PR TITLE
Add PCA anomaly detection model

### DIFF
--- a/anomaly_models/__init__.py
+++ b/anomaly_models/__init__.py
@@ -4,6 +4,7 @@ from .base import BaseAnomalyModel
 from .isolation_forest import IsolationForestModel
 from .local_outlier_factor import LocalOutlierFactorModel
 from .one_class_svm import OneClassSVMModel
+from .pca_detector import PCAAnomalyModel
 
 __all__ = [
     "BaseAnomalyModel",
@@ -11,4 +12,5 @@ __all__ = [
     "LocalOutlierFactorModel",
     "OneClassSVMModel",
     "AutoEncoderModel",
+    "PCAAnomalyModel",
 ]

--- a/anomaly_models/pca_detector.py
+++ b/anomaly_models/pca_detector.py
@@ -1,0 +1,39 @@
+"""PCA-based anomaly detection via reconstruction error."""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+from sklearn.decomposition import PCA  # type: ignore[import-untyped]
+
+from .base import ArrayLike, BaseAnomalyModel, NDArray
+
+
+class PCAAnomalyModel(BaseAnomalyModel):
+    """Principal Component Analysis reconstruction error detector."""
+
+    def __init__(self, n_components: int | None = None, **params: Optional[int]):
+        self.model = PCA(n_components=n_components, **params)
+        self._threshold: float | None = None
+
+    def fit(
+        self, X: ArrayLike, y: Optional[ArrayLike] | None = None
+    ) -> "PCAAnomalyModel":
+        self.model.fit(X)
+        return self
+
+    def score_samples(self, X: ArrayLike) -> NDArray:
+        transformed = self.model.transform(X)
+        recon = self.model.inverse_transform(transformed)
+        errors: NDArray = np.mean((X - recon) ** 2, axis=1)
+        return errors
+
+    @property
+    def decision_threshold(self) -> float:
+        if self._threshold is None:
+            raise RuntimeError("Model has no threshold set")
+        return self._threshold
+
+    def set_threshold(self, value: float) -> None:
+        self._threshold = value
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ The benchmark runner can be invoked from the command line::
 - ``local_outlier_factor``
 - ``one_class_svm``
 - ``autoencoder``
+- ``pca``
 
 This writes a JSON file compatible with ``results/results-schema.json``.
 

--- a/evaluator.py
+++ b/evaluator.py
@@ -20,6 +20,7 @@ from anomaly_models import (
     IsolationForestModel,
     LocalOutlierFactorModel,
     OneClassSVMModel,
+    PCAAnomalyModel,
 )
 from datasets.registry import load_dataset
 
@@ -28,6 +29,7 @@ MODEL_REGISTRY: dict[str, type[BaseAnomalyModel]] = {
     "isolation_forest": IsolationForestModel,
     "local_outlier_factor": LocalOutlierFactorModel,
     "one_class_svm": OneClassSVMModel,
+    "pca": PCAAnomalyModel,
 }
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from anomaly_models import (
     IsolationForestModel,
     LocalOutlierFactorModel,
     OneClassSVMModel,
+    PCAAnomalyModel,
 )
 
 
@@ -44,3 +45,7 @@ def test_one_class_svm() -> None:
 
 def test_autoencoder() -> None:
     _check_model(AutoEncoderModel(n_epochs=2))
+
+
+def test_pca_anomaly() -> None:
+    _check_model(PCAAnomalyModel())


### PR DESCRIPTION
## Summary
- implement PCAAnomalyModel using reconstruction error
- register PCA model in evaluator and package exports
- document new model in docs
- test PCA model alongside existing models

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687c99d5f7508324a73a7cde7afab036