### PR TITLE
Add wine and digits datasets

### DIFF
--- a/datasets/registry.py
+++ b/datasets/registry.py
@@ -152,10 +152,98 @@ def _breast_cancer(split: str, *, seed: int) -> Dataset:
     raise KeyError(f"Unknown split: {split}")
 
 
+def _wine(split: str, *, seed: int) -> Dataset:
+    """UCI Wine recognition dataset.
+
+    Class ``0`` (Cultivar 1) is considered normal. The training split
+    contains only this class. The test split is a stratified 20% hold-out
+    containing all three classes with non-normal samples labelled as
+    anomalies.
+
+    Data are loaded via :func:`sklearn.datasets.load_wine` and the split is
+    performed deterministically using
+    :func:`sklearn.model_selection.train_test_split` with ``seed``.
+
+    References
+    ----------
+    * M. Forina et al., "Parvus" dataset, 1991.
+    * D. Dua and C. Graff, "UCI Machine Learning Repository", 2019.
+    """
+
+    from sklearn.datasets import load_wine
+    from sklearn.model_selection import train_test_split
+
+    rng = np.random.default_rng(seed)
+
+    X, y = load_wine(return_X_y=True)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X,
+        y,
+        test_size=0.2,
+        random_state=rng.integers(0, 2**32 - 1),
+        stratify=y,
+    )
+
+    if split == "train":
+        X_norm = X_train[y_train == 0]
+        return X_norm.astype(np.float64), None
+
+    if split == "test":
+        y_test_anom = (y_test != 0).astype(int)
+        return X_test.astype(np.float64), y_test_anom
+
+    raise KeyError(f"Unknown split: {split}")
+
+
+def _digits(split: str, *, seed: int) -> Dataset:
+    """Scikit-learn digits dataset.
+
+    Digit ``0`` is treated as the normal class. The training split contains
+    only zeros. The test split is a stratified 20% hold-out containing all
+    digits with non-zero digits labelled as anomalies.
+
+    Data are loaded via :func:`sklearn.datasets.load_digits` and the split is
+    performed deterministically using
+    :func:`sklearn.model_selection.train_test_split` with ``seed``.
+
+    References
+    ----------
+    * K. Bache and M. Lichman, "UCI Machine Learning Repository", 2013.
+    """
+
+    from sklearn.datasets import load_digits
+    from sklearn.model_selection import train_test_split
+
+    rng = np.random.default_rng(seed)
+
+    X, y = load_digits(return_X_y=True)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X,
+        y,
+        test_size=0.2,
+        random_state=rng.integers(0, 2**32 - 1),
+        stratify=y,
+    )
+
+    if split == "train":
+        X_norm = X_train[y_train == 0]
+        return X_norm.astype(np.float64), None
+
+    if split == "test":
+        y_test_anom = (y_test != 0).astype(int)
+        return X_test.astype(np.float64), y_test_anom
+
+    raise KeyError(f"Unknown split: {split}")
+
+
 _REGISTRY = {
     "toy-blobs": _toy_blobs,
     "toy-circles": _toy_circles,
     "breast-cancer": _breast_cancer,
+    "wine": _wine,
+    "digits": _digits,
 }
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,3 +37,5 @@ The following dataset identifiers can be passed to
 - ``toy-blobs``
 - ``toy-circles``
 - ``breast-cancer``
+- ``wine``
+- ``digits``

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -79,3 +79,51 @@ def test_breast_cancer_shapes() -> None:
     assert y_test is not None
     assert y_test.ndim == 1
 
+
+def test_wine_deterministic() -> None:
+    X_train1, y_train1 = load_dataset("wine", split="train", seed=0)
+    X_train2, y_train2 = load_dataset("wine", split="train", seed=0)
+    X_test1, y_test1 = load_dataset("wine", split="test", seed=0)
+    X_test2, y_test2 = load_dataset("wine", split="test", seed=0)
+
+    assert y_train1 is None
+    assert y_train2 is None
+
+    npt.assert_array_equal(X_train1, X_train2)
+    npt.assert_array_equal(X_test1, X_test2)
+    npt.assert_array_equal(y_test1, y_test2)
+
+
+def test_wine_shapes() -> None:
+    X_train, y_train = load_dataset("wine", split="train")
+    X_test, y_test = load_dataset("wine", split="test")
+
+    assert y_train is None
+    assert X_train.shape[1] == X_test.shape[1] == 13
+    assert y_test is not None
+    assert y_test.ndim == 1
+
+
+def test_digits_deterministic() -> None:
+    X_train1, y_train1 = load_dataset("digits", split="train", seed=0)
+    X_train2, y_train2 = load_dataset("digits", split="train", seed=0)
+    X_test1, y_test1 = load_dataset("digits", split="test", seed=0)
+    X_test2, y_test2 = load_dataset("digits", split="test", seed=0)
+
+    assert y_train1 is None
+    assert y_train2 is None
+
+    npt.assert_array_equal(X_train1, X_train2)
+    npt.assert_array_equal(X_test1, X_test2)
+    npt.assert_array_equal(y_test1, y_test2)
+
+
+def test_digits_shapes() -> None:
+    X_train, y_train = load_dataset("digits", split="train")
+    X_test, y_test = load_dataset("digits", split="test")
+
+    assert y_train is None
+    assert X_train.shape[1] == X_test.shape[1] == 64
+    assert y_test is not None
+    assert y_test.ndim == 1
+


### PR DESCRIPTION
## Summary
- add UCI Wine and MNIST Digits loaders in `datasets.registry`
- register these datasets
- expand dataset unit tests for wine and digits
- document new dataset identifiers in the docs

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cac0dc5c48324bb2171a66a617f3d