### PR TITLE
Add Hypothesis-based ranking test and perf smoke benchmark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "scipy",
     "scikit-learn",
     "jsonschema",
+    "hypothesis",
 ]
 
 [project.optional-dependencies]

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from evaluator import run_benchmark
 
@@ -15,7 +15,7 @@ SCHEMA_PATH = Path("results/results-schema.json")
 
 def _validate(result: dict[str, Any]) -> None:
     """Validate ``result`` using ``results/results-schema.json``."""
-    import jsonschema  # type: ignore[import-untyped]
+    import jsonschema
 
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.validate(result, schema)

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from pathlib import Path as _Path
+
+import jsonschema
+import pytest
+
+sys.path.append(str(_Path(__file__).resolve().parents[2]))
+from evaluator import run_benchmark
+
+
+@pytest.mark.skipif(os.getenv("RUN_PERF") != "1", reason="Perf test")
+def test_benchmark_smoke(tmp_path: Path) -> None:
+    """Run a lightweight benchmark and validate schema."""
+    out = tmp_path / "result.json"
+    result = run_benchmark(
+        dataset="toy-blobs",
+        model_name="isolation_forest",
+        seed=0,
+        hardware="test",
+        output=out,
+        n_estimators=10,
+    )
+    schema = json.loads(Path("results/results-schema.json").read_text())
+    jsonschema.validate(result, schema)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import numpy as np
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from anomaly_models import IsolationForestModel
+from datasets.registry import load_dataset
+
+
+@given(
+    seed=st.integers(0, 1000),
+    scale=st.floats(0.5, 3.0, allow_nan=False, allow_infinity=False),
+    dx=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
+    dy=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=10)
+def test_ranking_invariance(seed: int, scale: float, dx: float, dy: float) -> None:
+    """Anomaly score ordering should be invariant to affine transforms."""
+    X_train, _ = load_dataset("toy-blobs", split="train", seed=seed)
+    X_test, _ = load_dataset("toy-blobs", split="test", seed=seed)
+
+    base = IsolationForestModel(random_state=seed, n_estimators=50).fit(X_train)
+    scores = base.score_samples(X_test)
+    order = np.argsort(scores)
+
+    shift = np.array([dx, dy], dtype=np.float64)
+    Xt = X_train * scale + shift
+    Xtt = X_test * scale + shift
+    transformed = IsolationForestModel(random_state=seed, n_estimators=50).fit(Xt)
+    scores_t = transformed.score_samples(Xtt)
+
+    np.testing.assert_array_equal(order, np.argsort(scores_t))


### PR DESCRIPTION
## Summary
- verify ranking invariance on toy blob data using Hypothesis
- add performance smoke benchmark in `tests/perf`
- expose `hypothesis` as a required dependency
- clean up type hints for `run_experiments`

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cabb6759c832495647fad4418b582