### PR TITLE
Add leaderboard benchmarking tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,12 @@ python evaluator.py \
     --model isolation_forest \
     --output results/example.json
 ```
+
+## Leaderboard
+
+Run ``leaderboard.py`` to benchmark all built-in tabular datasets and generate a
+Markdown leaderboard. Results are stored under ``results/leaderboard``.
+
+```bash
+python leaderboard.py --hardware CPU-unknown
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,13 @@ The benchmark runner can be invoked from the command line::
 
 This writes a JSON file compatible with ``results/results-schema.json``.
 
+## Leaderboard
+
+Use `leaderboard.py` to benchmark all built-in tabular datasets and aggregate the results into a Markdown table::
+
+    python leaderboard.py --hardware CPU-unknown
+
+
 ## Available datasets
 
 The following dataset identifiers can be passed to

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -1,0 +1,89 @@
+"""Benchmark predefined datasets and produce a leaderboard."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Sequence
+
+import pandas as pd
+
+from evaluator import run_benchmark
+
+DATASETS: Sequence[str] = ["breast-cancer", "wine", "digits"]
+
+MODELS: Sequence[str] = [
+    "isolation_forest",
+    "local_outlier_factor",
+    "one_class_svm",
+    "pca",
+]
+
+SCHEMA_PATH = Path("results/results-schema.json")
+
+
+def _validate(result: dict[str, Any]) -> None:
+    """Validate ``result`` against ``results-schema.json``."""
+    import jsonschema
+
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(result, schema)
+
+
+def run_all(
+    *,
+    datasets: Sequence[str] = DATASETS,
+    models: Sequence[str] = MODELS,
+    seed: int = 42,
+    hardware: str = "unknown",
+) -> list[dict[str, Any]]:
+    """Run benchmarks for all ``datasets`` and ``models``."""
+    results = []
+    for dataset in datasets:
+        for model_name in models:
+            out_file = Path(f"results/{dataset}/{model_name}.json")
+            result = run_benchmark(
+                dataset=dataset,
+                model_name=model_name,
+                seed=seed,
+                hardware=hardware,
+                output=out_file,
+            )
+            _validate(result)
+            results.append(result)
+    return results
+
+
+def write_leaderboard(results: Sequence[dict[str, Any]], out_dir: Path) -> None:
+    """Write aggregated ``results`` to ``out_dir``."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "leaderboard.json"
+    md_path = out_dir / "leaderboard.md"
+
+    with json_path.open("w") as f:
+        json.dump(list(results), f, indent=2)
+
+    df = (
+        pd.DataFrame(results)[["dataset", "model", "roc_auc", "pr_auc", "f1"]]
+        .sort_values(["dataset", "model"])
+        .reset_index(drop=True)
+    )
+    md_path.write_text(df.to_markdown(index=False))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run full benchmark suite")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--hardware", default="unknown")
+    parser.add_argument(
+        "--output_dir", type=Path, default=Path("results/leaderboard"),
+    )
+    args = parser.parse_args()
+
+    results = run_all(seed=args.seed, hardware=args.hardware)
+    write_leaderboard(results, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evaluator import run_benchmark
+from leaderboard import write_leaderboard
+
+
+@pytest.mark.skipif(pytest.importorskip("pandas") is None, reason="requires pandas")
+def test_write_leaderboard(tmp_path: Path) -> None:
+    result = run_benchmark(
+        dataset="toy-blobs",
+        model_name="isolation_forest",
+        seed=0,
+        hardware="test",
+        output=tmp_path / "res.json",
+        n_estimators=10,
+    )
+    write_leaderboard([result], tmp_path)
+    assert (tmp_path / "leaderboard.json").exists()
+    assert (tmp_path / "leaderboard.md").exists()
+

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -14,7 +14,7 @@ from datasets.registry import load_dataset
     dx=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
     dy=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
 )
-@settings(max_examples=10)
+@settings(max_examples=10, deadline=None)
 def test_ranking_invariance(seed: int, scale: float, dx: float, dy: float) -> None:
     """Anomaly score ordering should be invariant to affine transforms."""
     X_train, _ = load_dataset("toy-blobs", split="train", seed=seed)


### PR DESCRIPTION
## Summary
- add `leaderboard.py` to run benchmarks on bundled tabular datasets
- document leaderboard usage in README and docs
- add tests for leaderboard aggregation
- relax Hypothesis deadline in `test_ranking`

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cb768af7c8324aa9603e40e8a6ab3