### PR TITLE
Add NAB sliding-window loader and matrix profile model

### DIFF
--- a/anomaly_models/__init__.py
+++ b/anomaly_models/__init__.py
@@ -4,6 +4,7 @@ from .base import BaseAnomalyModel
 from .deep_svdd import DeepSVDDModel
 from .isolation_forest import IsolationForestModel
 from .local_outlier_factor import LocalOutlierFactorModel
+from .matrix_profile import MatrixProfileModel
 from .one_class_svm import OneClassSVMModel
 from .pca_detector import PCAAnomalyModel
 from .usad import USADModel
@@ -15,6 +16,7 @@ __all__ = [
     "OneClassSVMModel",
     "AutoEncoderModel",
     "PCAAnomalyModel",
+    "MatrixProfileModel",
     "DeepSVDDModel",
     "USADModel",
 ]

--- a/anomaly_models/base.py
+++ b/anomaly_models/base.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Optional
 
 import numpy as np
+from numpy.typing import NDArray as _NDArray
 
-ArrayLike = np.ndarray
-NDArray = np.ndarray
+ArrayLike = _NDArray[Any]
+NDArray = _NDArray[np.float64]
 
 
 class BaseAnomalyModel(ABC):

--- a/anomaly_models/matrix_profile.py
+++ b/anomaly_models/matrix_profile.py
@@ -1,0 +1,51 @@
+"""Matrix profile anomaly detector using STOMP."""
+from __future__ import annotations
+
+from typing import Optional, cast
+
+import numpy as np
+import stumpy  # type: ignore[import-untyped]
+
+from .base import ArrayLike, BaseAnomalyModel, NDArray
+
+
+def _reconstruct(windows: NDArray) -> NDArray:
+    """Reconstruct original series from windows."""
+    return np.concatenate([windows[0], windows[1:, -1]])
+
+
+class MatrixProfileModel(BaseAnomalyModel):
+    """STOMP-based matrix profile detector."""
+
+    def __init__(self, window_size: int = 24) -> None:
+        self.window_size = window_size
+        self.series_: NDArray | None = None
+        self._threshold: float | None = None
+
+    def fit(
+        self, X: ArrayLike, y: Optional[ArrayLike] | None = None
+    ) -> "MatrixProfileModel":
+        self.series_ = _reconstruct(np.asarray(X, dtype=np.float64))
+        return self
+
+    def score_samples(self, X: ArrayLike) -> NDArray:
+        if self.series_ is None:
+            raise RuntimeError("Model has not been fitted")
+
+        test_series = _reconstruct(np.asarray(X, dtype=np.float64))
+        full_series = np.concatenate([self.series_, test_series])
+        profile = cast(
+            NDArray,
+            stumpy.stump(full_series, m=self.window_size)[:, 0],
+        ).astype(np.float64)
+        start = len(self.series_) - self.window_size + 1
+        return profile[start : start + len(X)]
+
+    @property
+    def decision_threshold(self) -> float:
+        if self._threshold is None:
+            raise RuntimeError("Model has no threshold set")
+        return self._threshold
+
+    def set_threshold(self, value: float) -> None:
+        self._threshold = value

--- a/evaluator.py
+++ b/evaluator.py
@@ -20,6 +20,7 @@ from anomaly_models import (
     DeepSVDDModel,
     IsolationForestModel,
     LocalOutlierFactorModel,
+    MatrixProfileModel,
     OneClassSVMModel,
     PCAAnomalyModel,
     USADModel,
@@ -34,6 +35,7 @@ MODEL_REGISTRY: dict[str, type[BaseAnomalyModel]] = {
     "pca": PCAAnomalyModel,
     "deep_svdd": DeepSVDDModel,
     "usad": USADModel,
+    "matrix_profile": MatrixProfileModel,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 torch = ["torch>=2.0"]
 pandas = ["pandas>=2.0"]
 plot = ["matplotlib>=3.9"]
+ts = ["stumpy>=1.11"]
 
 [tool.ruff]
 line-length = 88

--- a/tests/perf/test_matrix_profile.py
+++ b/tests/perf/test_matrix_profile.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from evaluator import run_benchmark
+
+
+@pytest.mark.skipif(os.getenv("RUN_PERF") != "1", reason="Perf test")
+def test_matrix_profile_perf(tmp_path: Path) -> None:
+    out = tmp_path / "result.json"
+    result = run_benchmark(
+        dataset="nab-twitter-aapl",
+        model_name="matrix_profile",
+        seed=0,
+        hardware="test",
+        output=out,
+    )
+    schema = json.loads(Path("results/results-schema.json").read_text())
+    jsonschema.validate(result, schema)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -127,3 +127,14 @@ def test_digits_shapes() -> None:
     assert y_test is not None
     assert y_test.ndim == 1
 
+
+def test_nab_twitter_aapl_shapes() -> None:
+    X_train, y_train = load_dataset("nab-twitter-aapl", split="train")
+    X_test, y_test = load_dataset("nab-twitter-aapl", split="test")
+
+    assert y_train is None
+    assert X_train.shape[1] == 24
+    assert X_test.shape[1] == 24
+    assert y_test is not None
+    assert y_test.shape == (X_test.shape[0],)
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from anomaly_models import (
     DeepSVDDModel,
     IsolationForestModel,
     LocalOutlierFactorModel,
+    MatrixProfileModel,
     OneClassSVMModel,
     PCAAnomalyModel,
     USADModel,
@@ -59,3 +60,12 @@ def test_deep_svdd() -> None:
 
 def test_usad_model() -> None:
     _check_model(USADModel(n_epochs=2))
+
+
+def test_matrix_profile_model() -> None:
+    series = np.linspace(0, 1, 50)
+    window = 5
+    windows = np.lib.stride_tricks.sliding_window_view(series, window)
+    model = MatrixProfileModel(window_size=window).fit(windows[:-10])
+    scores = model.score_samples(windows[-10:])
+    assert scores.shape == (10,)


### PR DESCRIPTION
## Summary
- add STOMP-based `MatrixProfileModel`
- add NAB `Twitter_volume_AAPL` sliding window dataset loader
- wire new model into evaluator and registry
- add optional `stumpy` dependency
- test new dataset and model
- include performance benchmark for matrix profile

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb57e1738832488d4eff4f9320949