### PR TITLE
Fix typing for deep learning model outputs

### DIFF
--- a/anomaly_models/autoencoder.py
+++ b/anomaly_models/autoencoder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+import numpy as np
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -81,7 +82,7 @@ class AutoEncoderModel(BaseAnomalyModel):
         with torch.no_grad():
             recon = self.model(tensor_X)
             errors = torch.mean((recon - tensor_X) ** 2, dim=1)
-        return errors.cpu().numpy()
+        return np.asarray(errors.cpu().numpy(), dtype=np.float64)
 
     @property
     def decision_threshold(self) -> float:

--- a/anomaly_models/deep_svdd.py
+++ b/anomaly_models/deep_svdd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+import numpy as np
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -96,7 +97,7 @@ class DeepSVDDModel(BaseAnomalyModel):
         with torch.no_grad():
             feats = self.model(tensor_X)
             dist = torch.mean((feats - self.center) ** 2, dim=1)
-        return dist.cpu().numpy()
+        return np.asarray(dist.cpu().numpy(), dtype=np.float64)
 
     @property
     def decision_threshold(self) -> float:

--- a/anomaly_models/usad.py
+++ b/anomaly_models/usad.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+import numpy as np
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
@@ -123,7 +124,7 @@ class USADModel(BaseAnomalyModel):
             recon_loss1 = torch.mean((tensor_X - x1) ** 2, dim=1)
             recon_loss2 = torch.mean((tensor_X - x2) ** 2, dim=1)
             scores = self.cfg.alpha * recon_loss1 + (1 - self.cfg.alpha) * recon_loss2
-        return scores.cpu().numpy()
+        return np.asarray(scores.cpu().numpy(), dtype=np.float64)
 
     @property
     def decision_threshold(self) -> float:


### PR DESCRIPTION
## Summary
- return `np.ndarray` in autoencoder/deep_svdd/usad models
- keep lint happy

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q -k "not perf"`


------
https://chatgpt.com/codex/tasks/task_e_687d6ee1500483249fee228ce7e0914b