### PR TITLE
Implement Registry and base model threshold API

### DIFF
--- a/src/anml_exp/__init__.py
+++ b/src/anml_exp/__init__.py
@@ -1,0 +1,4 @@
+"""anml-exp package."""
+from .registry import Registry
+
+__all__ = ["Registry"]

--- a/src/anml_exp/models/autoencoder.py
+++ b/src/anml_exp/models/autoencoder.py
@@ -84,12 +84,5 @@ class AutoEncoderModel(BaseAnomalyModel):
             errors = torch.mean((recon - tensor_X) ** 2, dim=1)
         return np.asarray(errors.cpu().numpy(), dtype=np.float64)
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value
 

--- a/src/anml_exp/models/base.py
+++ b/src/anml_exp/models/base.py
@@ -2,7 +2,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Self
+
+if TYPE_CHECKING:  # pragma: no cover - for typing only
+    from anml_exp.registry import Registry
 
 import numpy as np
 from numpy.typing import NDArray as _NDArray
@@ -14,10 +17,17 @@ NDArray = _NDArray[np.float64]
 class BaseAnomalyModel(ABC):
     """Abstract base class for anomaly detection models."""
 
+    _threshold: float | None
+
+    def __init__(self) -> None:
+        # ``_threshold`` is initialised to ``None`` so subclasses are not
+        # forced to call ``super().__init__``.
+        self._threshold = None
+
     @abstractmethod
     def fit(
         self, X: ArrayLike, y: Optional[ArrayLike] | None = None
-    ) -> "BaseAnomalyModel":
+    ) -> Self:
         """Fit the model."""
         raise NotImplementedError
 
@@ -34,7 +44,27 @@ class BaseAnomalyModel(ABC):
         return (scores >= threshold).astype(int)
 
     @property
-    @abstractmethod
     def decision_threshold(self) -> float:
-        """Threshold used for ``predict``."""
-        raise NotImplementedError
+        """Threshold used for :meth:`predict`."""
+        if self._threshold is None:
+            raise RuntimeError("Model has no threshold set")
+        return self._threshold
+
+    def set_threshold(self, value: float) -> None:
+        """Set the :attr:`decision_threshold`."""
+        self._threshold = value
+
+    # ------------------------------------------------------------------
+    # Optional artefact persistence helpers
+    # ------------------------------------------------------------------
+    def save(self, registry: "Registry", name: str, version: str) -> str:
+        """Save ``self`` to ``registry`` and return its digest."""
+        return registry.save(self, name, version)
+
+    @classmethod
+    def load(cls: type[Self], registry: "Registry", name: str, version: str) -> Self:
+        """Load an instance from ``registry``."""
+        obj = registry.load(name, version)
+        if not isinstance(obj, cls):
+            raise TypeError(f"Loaded artefact is not a {cls.__name__}")
+        return obj

--- a/src/anml_exp/models/deep_svdd.py
+++ b/src/anml_exp/models/deep_svdd.py
@@ -99,11 +99,4 @@ class DeepSVDDModel(BaseAnomalyModel):
             dist = torch.mean((feats - self.center) ** 2, dim=1)
         return np.asarray(dist.cpu().numpy(), dtype=np.float64)
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value

--- a/src/anml_exp/models/isolation_forest.py
+++ b/src/anml_exp/models/isolation_forest.py
@@ -25,11 +25,4 @@ class IsolationForestModel(BaseAnomalyModel):
         scores: NDArray = -self.model.decision_function(X)
         return scores
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value

--- a/src/anml_exp/models/local_outlier_factor.py
+++ b/src/anml_exp/models/local_outlier_factor.py
@@ -26,11 +26,4 @@ class LocalOutlierFactorModel(BaseAnomalyModel):
         scores: NDArray = -self.model.score_samples(X)
         return scores
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value

--- a/src/anml_exp/models/matrix_profile.py
+++ b/src/anml_exp/models/matrix_profile.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Optional, cast
 
 import numpy as np
-import stumpy  # type: ignore[import-untyped]
+import stumpy  # type: ignore[import-not-found]
 
 from .base import ArrayLike, BaseAnomalyModel, NDArray
 
@@ -41,11 +41,4 @@ class MatrixProfileModel(BaseAnomalyModel):
         start = len(self.series_) - self.window_size + 1
         return profile[start : start + len(X)]
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value

--- a/src/anml_exp/models/one_class_svm.py
+++ b/src/anml_exp/models/one_class_svm.py
@@ -25,11 +25,4 @@ class OneClassSVMModel(BaseAnomalyModel):
         scores: NDArray = -self.model.decision_function(X)
         return scores
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value

--- a/src/anml_exp/models/pca_detector.py
+++ b/src/anml_exp/models/pca_detector.py
@@ -28,12 +28,5 @@ class PCAAnomalyModel(BaseAnomalyModel):
         errors: NDArray = np.mean((X - recon) ** 2, axis=1)
         return errors
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value
 

--- a/src/anml_exp/models/usad.py
+++ b/src/anml_exp/models/usad.py
@@ -126,11 +126,4 @@ class USADModel(BaseAnomalyModel):
             scores = self.cfg.alpha * recon_loss1 + (1 - self.cfg.alpha) * recon_loss2
         return np.asarray(scores.cpu().numpy(), dtype=np.float64)
 
-    @property
-    def decision_threshold(self) -> float:
-        if self._threshold is None:
-            raise RuntimeError("Model has no threshold set")
-        return self._threshold
 
-    def set_threshold(self, value: float) -> None:
-        self._threshold = value

--- a/src/anml_exp/registry/__init__.py
+++ b/src/anml_exp/registry/__init__.py
@@ -1,0 +1,58 @@
+"""Simple artefact registry with versioned storage."""
+from __future__ import annotations
+
+import hashlib
+import json
+import pickle
+from pathlib import Path
+from typing import Any
+
+__all__ = ["Registry"]
+
+
+class Registry:
+    """Versioned artefact registry using SHA-256 digests."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+
+    # Internal helper to compute sha256 digest of a file
+    @staticmethod
+    def _digest_file(path: Path) -> str:
+        h = hashlib.sha256()
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(8192), b""):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def _artefact_dir(self, name: str, version: str) -> Path:
+        return self.root / name / version
+
+    def save(self, obj: Any, name: str, version: str) -> str:
+        """Save ``obj`` and return its ``sha256`` digest."""
+        path = self._artefact_dir(name, version)
+        path.mkdir(parents=True, exist_ok=True)
+        artefact = path / "artefact.pkl"
+        with artefact.open("wb") as f:
+            pickle.dump(obj, f)
+        digest = self._digest_file(artefact)
+        meta = {"digest": f"sha256:{digest}"}
+        with (path / "metadata.json").open("w") as f:
+            json.dump(meta, f)
+        return meta["digest"]
+
+    def load(self, name: str, version: str) -> Any:
+        """Load an artefact verifying its digest."""
+        path = self._artefact_dir(name, version)
+        artefact = path / "artefact.pkl"
+        meta_path = path / "metadata.json"
+        with meta_path.open() as f:
+            meta = json.load(f)
+        expected = meta.get("digest")
+        if not expected or not expected.startswith("sha256:"):
+            raise RuntimeError("Invalid metadata")
+        digest = self._digest_file(artefact)
+        if digest != expected.split(":", 1)[1]:
+            raise RuntimeError("Digest mismatch")
+        with artefact.open("rb") as f:
+            return pickle.load(f)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from anml_exp.registry import Registry
+
+
+def test_registry_roundtrip(tmp_path):
+    registry = Registry(tmp_path)
+    obj = {"a": 1}
+    digest = registry.save(obj, "dummy", "0.1.0")
+    assert digest.startswith("sha256:")
+    loaded = registry.load("dummy", "0.1.0")
+    assert loaded == obj


### PR DESCRIPTION
## Summary
- add `Registry` for model artefact versioning
- enhance `BaseAnomalyModel` with threshold management and save/load helpers
- remove redundant threshold code from models
- export `Registry` from package root
- test registry roundtrip

## Testing
- `ruff check .`
- `mypy src/anml_exp`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d7a3e6f748324977a43bb65eaa98e