### PR TITLE
Implement runtime dataset download with hash checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,11 @@ jobs:
         python -m pip install --upgrade pip
         uv pip sync -r uv.lock
 
+    - name: Download datasets
+      run: |
+        . .venv/bin/activate
+        python -m anml_exp.data.registry --fetch
+
     - name: Ruff
       run: |
         . .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,4 +45,5 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "anml_exp.resources" = ["results-schema.json"]
+"anml_exp.data" = ["datasets/*"]
 

--- a/src/anml_exp/data/__init__.py
+++ b/src/anml_exp/data/__init__.py
@@ -1,4 +1,4 @@
 """Dataset loading utilities."""
-from .registry import load_dataset
+from .registry import HashError, load_dataset, prepare_datasets
 
-__all__ = ["load_dataset"]
+__all__ = ["load_dataset", "prepare_datasets", "HashError"]

--- a/src/anml_exp/data/datasets/README.md
+++ b/src/anml_exp/data/datasets/README.md
@@ -1,0 +1,1 @@
+datasets downloaded during tests

--- a/src/anml_exp/models/matrix_profile.py
+++ b/src/anml_exp/models/matrix_profile.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Optional, cast
 
 import numpy as np
-import stumpy  # type: ignore[import-not-found]
+import stumpy  # type: ignore[import-untyped]
 
 from .base import ArrayLike, BaseAnomalyModel, NDArray
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from anml_exp.registry import Registry
 
 
-def test_registry_roundtrip(tmp_path):
+def test_registry_roundtrip(tmp_path: Path) -> None:
     registry = Registry(tmp_path)
     obj = {"a": 1}
     digest = registry.save(obj, "dummy", "0.1.0")


### PR DESCRIPTION
## Summary
- download datasets on first use instead of shipping files
- generate sklearn dataset files to fixed digests
- expose `prepare_datasets` helper and CLI
- fetch datasets in CI before running tests
- update matrix profile type-ignore comment

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d80c36da48324b5bfd42453fb1080