### PR TITLE
Structured hardware schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ Run the ``leaderboard`` command to benchmark all built-in tabular datasets and
 generate a Markdown leaderboard. Results are stored under ``results/leaderboard``.
 
 ```bash
-python -m anml_exp.cli leaderboard --hardware CPU-unknown
+python -m anml_exp.cli leaderboard --hardware '{"device_type":"CPU","vendor":"unknown","model":"unknown","driver":"N/A","num_devices":1,"notes":"example"}'
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ This writes a JSON file compatible with ``anml_exp/resources/results-schema.json
 
 Use the ``leaderboard`` command to benchmark all built-in tabular datasets and aggregate the results into a Markdown table::
 
-    python -m anml_exp.cli leaderboard --hardware CPU-unknown
+    python -m anml_exp.cli leaderboard --hardware '{"device_type":"CPU","vendor":"unknown","model":"unknown","driver":"N/A","num_devices":1,"notes":"example"}'
 
 
 ## Available datasets

--- a/experiments/toy-blobs.yaml
+++ b/experiments/toy-blobs.yaml
@@ -1,7 +1,13 @@
 # Experiment: toy-blobs dataset with all reference models
 dataset: toy-blobs
 seed: 42
-hardware: CPU-unknown
+hardware:
+  device_type: CPU
+  vendor: unknown
+  model: unknown
+  driver: N/A
+  num_devices: 1
+  notes: example
 output_dir: results/toy-blobs
 models:
   isolation_forest:

--- a/experiments/toy-circles.yaml
+++ b/experiments/toy-circles.yaml
@@ -1,7 +1,13 @@
 # Experiment: toy-circles dataset with all reference models
 dataset: toy-circles
 seed: 42
-hardware: CPU-unknown
+hardware:
+  device_type: CPU
+  vendor: unknown
+  model: unknown
+  driver: N/A
+  num_devices: 1
+  notes: example
 output_dir: results/toy-circles
 models:
   isolation_forest:

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -7,16 +7,16 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
-from anml_exp.benchmarks.evaluator import run_benchmark
+from anml_exp.benchmarks.evaluator import _normalize_hardware, run_benchmark
 
 SCHEMA_PATH = files("anml_exp.resources").joinpath("results-schema.json")
 
 
 def _validate(result: dict[str, Any]) -> None:
     """Validate ``result`` using ``results/results-schema.json``."""
-    import jsonschema
+    import jsonschema  # type: ignore[import-untyped]
 
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.validate(result, schema)
@@ -27,7 +27,8 @@ def _run(config: Path) -> None:
 
     dataset = data["dataset"]
     seed = int(data.get("seed", 42))
-    hardware = str(data.get("hardware", "unknown"))
+    hardware = data.get("hardware", "unknown")
+    hardware = _normalize_hardware(hardware)
     output_dir = Path(data.get("output_dir", f"results/{config.stem}"))
 
     models: dict[str, Any] = data["models"]

--- a/src/anml_exp/__init__.py
+++ b/src/anml_exp/__init__.py
@@ -1,4 +1,11 @@
 """anml-exp package."""
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("anml-exp")
+except PackageNotFoundError:  # pragma: no cover - fallback during dev
+    __version__ = "0.0.1"
+
 from .registry import Registry
 
 __all__ = ["Registry"]

--- a/src/anml_exp/benchmarks/leaderboard.py
+++ b/src/anml_exp/benchmarks/leaderboard.py
@@ -5,11 +5,11 @@ import argparse
 import json
 from importlib.resources import files
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
-import pandas as pd
+import pandas as pd  # type: ignore[import-untyped]
 
-from .evaluator import run_benchmark
+from .evaluator import _normalize_hardware, run_benchmark
 
 DATASETS: Sequence[str] = ["breast-cancer", "wine", "digits"]
 
@@ -25,7 +25,7 @@ SCHEMA_PATH = files("anml_exp.resources").joinpath("results-schema.json")
 
 def _validate(result: dict[str, Any]) -> None:
     """Validate ``result`` against ``results-schema.json``."""
-    import jsonschema
+    import jsonschema  # type: ignore[import-untyped]
 
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.validate(result, schema)
@@ -36,9 +36,10 @@ def run_all(
     datasets: Sequence[str] = DATASETS,
     models: Sequence[str] = MODELS,
     seed: int = 42,
-    hardware: str = "unknown",
+    hardware: str | Mapping[str, Any] = "unknown",
 ) -> list[dict[str, Any]]:
     """Run benchmarks for all ``datasets`` and ``models``."""
+    hw = _normalize_hardware(hardware)
     results = []
     for dataset in datasets:
         for model_name in models:
@@ -47,7 +48,7 @@ def run_all(
                 dataset=dataset,
                 model_name=model_name,
                 seed=seed,
-                hardware=hardware,
+                hardware=hw,
                 output=out_file,
             )
             _validate(result)

--- a/src/anml_exp/cli.py
+++ b/src/anml_exp/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 from typing import Any
 
@@ -30,17 +31,27 @@ def main(argv: list[str] | None = None) -> None:
         model_params: dict[str, Any] = {
             k: eval(v) for k, v in (kv.split("=", 1) for kv in unknown if "=" in kv)
         }
+        hw = (
+            json.loads(args.hardware)
+            if args.hardware.strip().startswith("{")
+            else args.hardware
+        )
         result = run_benchmark(
             dataset=args.dataset,
             model_name=args.model,
             seed=args.seed,
-            hardware=args.hardware,
+            hardware=hw,
             output=args.output,
             **model_params,
         )
         print(result)
     elif args.command == "leaderboard":
-        results = run_all(seed=args.seed, hardware=args.hardware)
+        hw = (
+            json.loads(args.hardware)
+            if args.hardware.strip().startswith("{")
+            else args.hardware
+        )
+        results = run_all(seed=args.seed, hardware=hw)
         write_leaderboard(results, args.output_dir)
 
 

--- a/src/anml_exp/resources/results-schema.json
+++ b/src/anml_exp/resources/results-schema.json
@@ -5,9 +5,29 @@
   "properties": {
     "dataset": {"type": "string"},
     "model": {"type": "string"},
+    "model_version": {"type": "string"},
+    "artefact_digest": {"type": "string"},
     "n_samples": {"type": "integer"},
     "seed": {"type": "integer"},
-    "hardware": {"type": "string"},
+    "hardware": {
+      "type": "object",
+      "properties": {
+        "device_type": {"type": "string"},
+        "vendor": {"type": "string"},
+        "model": {"type": "string"},
+        "driver": {"type": "string"},
+        "num_devices": {"type": "integer"},
+        "notes": {"type": "string"}
+      },
+      "required": [
+        "device_type",
+        "vendor",
+        "model",
+        "driver",
+        "num_devices",
+        "notes"
+      ]
+    },
     "roc_auc": {"type": "number"},
     "pr_auc": {"type": "number"},
     "f1": {"type": "number"},
@@ -17,8 +37,18 @@
     "params": {"type": "object"}
   },
   "required": [
-    "dataset", "model", "n_samples", "seed", "hardware",
-    "roc_auc", "pr_auc", "f1", "threshold", "fit_time",
-    "score_time", "params"
+    "dataset",
+    "model",
+    "model_version",
+    "n_samples",
+    "seed",
+    "hardware",
+    "roc_auc",
+    "pr_auc",
+    "f1",
+    "threshold",
+    "fit_time",
+    "score_time",
+    "params"
   ]
 }

--- a/tests/perf/test_benchmark.py
+++ b/tests/perf/test_benchmark.py
@@ -5,7 +5,7 @@ import os
 from importlib.resources import files
 from pathlib import Path
 
-import jsonschema
+import jsonschema  # type: ignore[import-untyped]
 import pytest
 
 from anml_exp.benchmarks.evaluator import run_benchmark
@@ -19,7 +19,14 @@ def test_benchmark_smoke(tmp_path: Path) -> None:
         dataset="toy-blobs",
         model_name="isolation_forest",
         seed=0,
-        hardware="test",
+        hardware={
+            "device_type": "CPU",
+            "vendor": "test",
+            "model": "generic",
+            "driver": "N/A",
+            "num_devices": 1,
+            "notes": "test",
+        },
         output=out,
         n_estimators=10,
     )

--- a/tests/perf/test_matrix_profile.py
+++ b/tests/perf/test_matrix_profile.py
@@ -5,7 +5,7 @@ import os
 from importlib.resources import files
 from pathlib import Path
 
-import jsonschema
+import jsonschema  # type: ignore[import-untyped]
 import pytest
 
 from anml_exp.benchmarks.evaluator import run_benchmark
@@ -18,7 +18,14 @@ def test_matrix_profile_perf(tmp_path: Path) -> None:
         dataset="nab-twitter-aapl",
         model_name="matrix_profile",
         seed=0,
-        hardware="test",
+        hardware={
+            "device_type": "CPU",
+            "vendor": "test",
+            "model": "generic",
+            "driver": "N/A",
+            "num_devices": 1,
+            "notes": "test",
+        },
         output=out,
     )
     schema = json.loads(

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -14,7 +14,14 @@ def test_write_leaderboard(tmp_path: Path) -> None:
         dataset="toy-blobs",
         model_name="isolation_forest",
         seed=0,
-        hardware="test",
+        hardware={
+            "device_type": "CPU",
+            "vendor": "test",
+            "model": "generic",
+            "driver": "N/A",
+            "num_devices": 1,
+            "notes": "test",
+        },
         output=tmp_path / "res.json",
         n_estimators=10,
     )


### PR DESCRIPTION
## Summary
- expand `results-schema.json` with structured `hardware` section and versioning fields
- capture package version and hardware details in benchmark results
- update CLI and utilities to parse hardware JSON
- adjust docs and example experiments for new format
- update tests for schema changes

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687da285bf0883249eb5e8d068c908ce