### PR TITLE
Update version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,10 @@ All notable changes to this project are documented in this file.
 ## [Unreleased]
 - Added `CONTRIBUTING.md` and started the changelog.
 
+## [0.3.1] - 2025-07-21
+- Updated project to spec version **0.3.1**.
+- Introduced `uv.lock` for reproducible installs and dataset SHA-256 checks.
+- Benchmarks now record structured hardware info and save artefacts via the registry.
+
 ## [0.2.0] - 2025-07-20
 - Initial spec drafted in `Agents.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "anml-exp"
-version = "0.0.1"
+version = "0.3.1"
 description = "Anomaly detection experimentation framework"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/anml_exp/__init__.py
+++ b/src/anml_exp/__init__.py
@@ -4,7 +4,7 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("anml-exp")
 except PackageNotFoundError:  # pragma: no cover - fallback during dev
-    __version__ = "0.0.1"
+    __version__ = "0.3.1"
 
 from .registry import Registry
 

--- a/src/anml_exp/benchmarks/evaluator.py
+++ b/src/anml_exp/benchmarks/evaluator.py
@@ -100,7 +100,7 @@ def run_benchmark(
     try:
         model_version = __version__
     except Exception:
-        model_version = "0.0.1"
+        model_version = "0.3.1"
     artefact_digest = None
     if registry is not None:
         artefact_digest = model.save(registry, model_name, model_version)

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "anml-exp"
-version = "0.0.1"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "hypothesis" },


### PR DESCRIPTION
## Summary
- bump package version to 0.3.1
- document spec version 0.3.1 in CHANGELOG
- update fallback `__version__` references
- sync uv.lock

## Testing
- `ruff check .`
- `mypy .`
- `uv lock --check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687dd6f25f788324b38a96bdd54051fb