### PR TITLE
Fix CI uv sync command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         python -m venv .venv
         . .venv/bin/activate
-        uv pip sync -r uv.lock
+        uv sync --frozen
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
       run: |
         . .venv/bin/activate
         python -m pip install --upgrade pip
-        uv pip sync -r uv.lock
+        uv sync --frozen
 
     - name: Download datasets
       run: |

--- a/Agents.md
+++ b/Agents.md
@@ -1,4 +1,4 @@
-# Agents.md   ― spec _version: **0.3.1**  (2025-07-20)
+# Agents.md   ― spec _version: **0.3.2**  (2025-07-21)
 
 > **TL;DR**    
 > `anml-exp` is a *pip-installable* anomaly-detection playground with locked
@@ -165,7 +165,7 @@ flowchart TD
     draft --> review --> maintainer
 
 CI additionally ensures:
-	•	uv pip sync -r uv.lock produces identical env (#42).
+	•	uv sync --frozen produces identical env (#42).
 	•	Dataset SHA-256s match declared values (#44).
 
 ⸻
@@ -189,7 +189,7 @@ CI additionally ensures:
 8 · Installation & Quick-Start
 
 # Reproducible dev install
-uv pip sync -r uv.lock
+uv sync --frozen
 pip install -e ".[torch,plot]"
 # After release:
 pip install anml-exp[torch,plot]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Only humans can merge PRs. Reviewer also re-runs checks on `main` nightly to cat
 - `ruff` for linting and formatting.
 - `mypy --strict` for type checking.
 - `pytest` for the unit test suite.
-- `uv pip sync -r uv.lock` to ensure the environment matches the lock file.
+- `uv sync --frozen` to ensure the environment matches the lock file.
 - Dataset SHA-256 verification.
 
 The Reviewer role ensures these checks succeed before a PR can be merged.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A unified interface to prototype and test anomaly detection methods.
 Create a reproducible environment with `uv` and install optional extras as needed:
 
 ```bash
-uv pip sync -r uv.lock
+uv sync --frozen
 pip install -e ".[torch,plot]"
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@
 Create the Python environment from the lock file before installing the project:
 
 ```bash
-uv pip sync -r uv.lock
+uv sync --frozen
 pip install -e ".[torch,plot]"
 ```
 


### PR DESCRIPTION
## Summary
- adjust CI workflow for uv 0.8
- update docs to use `uv sync --frozen`
- bump Agents.md spec version

## Testing
- `ruff check .`
- `mypy --strict .` *(fails: unused ignore comments)*
- `pytest -vv -n auto` *(fails: FileNotFoundError in dataset hash test)*

------
https://chatgpt.com/codex/tasks/task_e_687ddba8baf48324967b963755754349