### PR TITLE
Fix ruff missing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         python -m venv .venv
         . .venv/bin/activate
-        uv sync --frozen
+        uv sync --frozen --extra dev --extra torch
         echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
       run: |
         . .venv/bin/activate
         python -m pip install --upgrade pip
-        uv sync --frozen
+        uv sync --frozen --extra dev --extra torch
 
     - name: Download datasets
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ select = ["E", "F", "I"]
 python_version = "3.11"
 strict = true
 mypy_path = ["src"]
+[[tool.mypy.overrides]]
+module = ["torch", "torch.*"]
+ignore_missing_imports = true
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/run_experiments.py
+++ b/run_experiments.py
@@ -7,7 +7,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from anml_exp.benchmarks.evaluator import _normalize_hardware, run_benchmark
 
@@ -16,7 +16,7 @@ SCHEMA_PATH = files("anml_exp.resources").joinpath("results-schema.json")
 
 def _validate(result: dict[str, Any]) -> None:
     """Validate ``result`` using ``results/results-schema.json``."""
-    import jsonschema  # type: ignore[import-untyped]
+    import jsonschema
 
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.validate(result, schema)

--- a/src/anml_exp/benchmarks/leaderboard.py
+++ b/src/anml_exp/benchmarks/leaderboard.py
@@ -7,7 +7,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-import pandas as pd  # type: ignore[import-untyped]
+import pandas as pd
 
 from .evaluator import _normalize_hardware, run_benchmark
 
@@ -25,7 +25,7 @@ SCHEMA_PATH = files("anml_exp.resources").joinpath("results-schema.json")
 
 def _validate(result: dict[str, Any]) -> None:
     """Validate ``result`` against ``results-schema.json``."""
-    import jsonschema  # type: ignore[import-untyped]
+    import jsonschema
 
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.validate(result, schema)

--- a/src/anml_exp/models/__init__.py
+++ b/src/anml_exp/models/__init__.py
@@ -1,28 +1,39 @@
 """Anomaly detection models."""
-from .autoencoder import AutoEncoderModel
 from .base import BaseAnomalyModel
-from .deep_svdd import DeepSVDDModel
 from .isolation_forest import IsolationForestModel
 from .local_outlier_factor import LocalOutlierFactorModel
+
+try:
+    from .autoencoder import AutoEncoderModel
+    from .deep_svdd import DeepSVDDModel
+    from .usad import USADModel
+except Exception:  # pragma: no cover - optional dependency missing
+    AutoEncoderModel = None  # type: ignore[misc,assignment]
+    DeepSVDDModel = None  # type: ignore[misc,assignment]
+    USADModel = None  # type: ignore[misc,assignment]
 
 try:
     from .matrix_profile import MatrixProfileModel
 except Exception:  # pragma: no cover - optional dependency missing
     MatrixProfileModel = None  # type: ignore[misc,assignment]
+
 from .one_class_svm import OneClassSVMModel
 from .pca_detector import PCAAnomalyModel
-from .usad import USADModel
 
 __all__ = [
     "BaseAnomalyModel",
     "IsolationForestModel",
     "LocalOutlierFactorModel",
     "OneClassSVMModel",
-    "AutoEncoderModel",
     "PCAAnomalyModel",
-    "DeepSVDDModel",
-    "USADModel",
 ]
+
+if AutoEncoderModel is not None:
+    __all__.append("AutoEncoderModel")
+if DeepSVDDModel is not None:
+    __all__.append("DeepSVDDModel")
+if USADModel is not None:
+    __all__.append("USADModel")
 
 if MatrixProfileModel is not None:
     __all__.append("MatrixProfileModel")

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -4,20 +4,20 @@ import numpy as np
 import pytest
 
 pytest.importorskip("hypothesis")
-from hypothesis import given, settings  # type: ignore[import-not-found]
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from anml_exp.data import load_dataset
-from anml_exp.models import IsolationForestModel
+from anml_exp.models.isolation_forest import IsolationForestModel
 
 
-@given(  # type: ignore[misc]
+@given(
     seed=st.integers(0, 1000),
     scale=st.floats(0.5, 3.0, allow_nan=False, allow_infinity=False),
     dx=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
     dy=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
 )
-@settings(max_examples=10, deadline=None)  # type: ignore[misc]
+@settings(max_examples=10, deadline=None)
 def test_ranking_invariance(seed: int, scale: float, dx: float, dy: float) -> None:
     """Anomaly score ordering should be invariant to affine transforms."""
     X_train, _ = load_dataset("toy-blobs", split="train", seed=seed)


### PR DESCRIPTION
## Summary
- ensure CI installs dev and torch extras
- teach mypy to ignore missing torch stubs
- drop unused type-ignores
- make heavy models optional during package import
- clean up ranking test imports

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -vv -n auto`

------
https://chatgpt.com/codex/tasks/task_e_687e002ebc748324a4d99180d149ae5f