### PR TITLE
Fix YAML quoting in typing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       run: python -m pip install uv
 
     - name: Restore venv
+      id: restore-venv
       uses: actions/cache/restore@v4
       with:
         path: .venv

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -19,12 +19,12 @@ jobs:
           uv sync --frozen --extra dev
           uv pip install --upgrade --only-binary=:all: "mypy[faster-cache]>=1.13"
           
-      - name: Debug: where + version
+      - name: "Debug: where + version"
         run: |
           ls -l .venv/bin/mypy || true
           .venv/bin/mypy --version || true
 
-      - name: Debug: pip list
+      - name: "Debug: pip list"
         run: .venv/bin/pip list | grep -E '^(mypyc|mypy)'
 
 


### PR DESCRIPTION
## Summary
- quote step names containing a colon in `typing.yml`
- add missing `id` for `restore-venv` step in `ci.yml`

## Testing
- `ruff check .`
- `uv lock --check`
- `pytest -vv -n auto`


------
https://chatgpt.com/codex/tasks/task_e_68803ec9574c8324b038e5777ea22de7